### PR TITLE
Update privacy page logo to match app branding

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -14,18 +14,11 @@
             <div class="flex justify-between h-16">
                 <div class="flex items-center">
                     <a href="/" class="flex items-center space-x-2">
-                        <svg class="w-8 h-8" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-                            <defs>
-                                <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                                    <stop offset="0%" style="stop-color:#10b981;stop-opacity:1" />
-                                    <stop offset="100%" style="stop-color:#9333ea;stop-opacity:1" />
-                                </linearGradient>
-                            </defs>
-                            <rect x="10" y="20" width="15" height="60" fill="url(#logoGradient)" rx="2"/>
-                            <rect x="35" y="35" width="15" height="45" fill="url(#logoGradient)" rx="2"/>
-                            <rect x="60" y="15" width="15" height="65" fill="url(#logoGradient)" rx="2"/>
-                            <rect x="85" y="40" width="15" height="40" fill="url(#logoGradient)" rx="2" opacity="0.6"/>
-                        </svg>
+                        <div class="bg-gradient-to-br from-green-500 to-purple-600 p-1.5 rounded-lg">
+                            <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                            </svg>
+                        </div>
                         <span class="text-xl font-bold text-gray-900">GitStreak</span>
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
Updates the privacy policy page logo to use the official GitStreak bar chart icon with gradient background, matching the app's visual identity.

## Changes
- Replaced placeholder SVG logo with the official bar chart icon
- Added gradient background container (green to purple)
- Maintains consistent branding across all pages

## Visual Update
The new logo features:
- Bar chart icon representing contribution tracking
- Gradient background matching app theme (from-green-500 to-purple-600)
- White icon on gradient background for better visibility

## Test Plan
- [x] Verify logo displays correctly on privacy page
- [x] Confirm gradient background renders properly
- [x] Check navigation link functionality
- [ ] Deploy and verify on production

🤖 Generated with [Claude Code](https://claude.ai/code)